### PR TITLE
Use ActiveModel::Errors api to get I18n support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Todo
 
 Lots of improvements can be made:
 
-* Add I18n of error messages
+* Add I18n specific types of error messages for each validator
 * Implement new validators
 * ...
 

--- a/lib/active_model/validations/email_validator.rb
+++ b/lib/active_model/validations/email_validator.rb
@@ -11,7 +11,7 @@ module ActiveModel
         rescue Exception => e
           r = false
         end
-        record.errors[attribute] << (options[:message] || "is invalid") unless r
+        record.errors.add(attribute) unless r
       end
     end
   end

--- a/lib/active_model/validations/phone_validator.rb
+++ b/lib/active_model/validations/phone_validator.rb
@@ -3,7 +3,7 @@ module ActiveModel
     class PhoneValidator < EachValidator
       def validate_each(record, attribute, value)
         unless value =~ /^\d{3}-\d{3}-\d{4}|\d{3}\.\d{3}\.\d{4}|\d{10}|\d{3}\s\d{3}\s\d{4}|\(\d{3}\)\s\d{3}-\d{4}$/i
-          record.errors[attribute] << (options[:message] || "is invalid") 
+          record.errors.add(attribute)
         end
       end
     end

--- a/lib/active_model/validations/respond_to_validator.rb
+++ b/lib/active_model/validations/respond_to_validator.rb
@@ -6,7 +6,7 @@ module ActiveModel
         responders = options.dup
         RESERVED_OPTIONS.each do |opt,should_apply| responders.delete(opt) end
         responders.each do |method,dummy|
-          record.errors[attribute] << (options[:message] || "is invalid") unless value.respond_to? method
+          record.errors.add(attribute) unless value.respond_to? method
         end
       end
     end

--- a/lib/active_model/validations/url_validator.rb
+++ b/lib/active_model/validations/url_validator.rb
@@ -3,7 +3,7 @@ module ActiveModel
     class UrlValidator < EachValidator
       def validate_each(record, attribute, value)
         unless value =~ /^https?:\/\/(?i)[a-z0-9]+([-.]{1}[a-z0-9]+)*.[a-z]{2,5}(([0-9]{1,5})?\/.*)?$/
-          record.errors[attribute] << (options[:message] || "is invalid") 
+          record.errors.add(attribute)
         end
       end
     end

--- a/spec/specs/email_spec.rb
+++ b/spec/specs/email_spec.rb
@@ -4,14 +4,25 @@ describe "Email Validation" do
   it "accepts valid emails" do
     model = Models::EmailValidatorModel.new
     model.email = 'franck@verrot.fr'
-    model.valid?.should == true
+    model.valid?.should be(true)
     model.should have(0).errors
   end
 
-  it "rejected invalid emails" do
-    model = Models::EmailValidatorModel.new
-    model.email = 'franck.fr'
-    model.valid?.should == false
-    model.should have(1).errors
+  describe "for invalid emails" do
+    let(:model) do
+      Models::EmailValidatorModel.new.tap do |m|
+        m.email = 'franck.fr'
+      end
+    end
+
+    it "rejects invalid emails" do
+      model.valid?.should be(false)
+      model.should have(1).errors
+    end
+
+    it "generates an error message of type invalid" do
+      model.valid?.should be(false)
+      model.errors[:email].should == [model.errors.generate_message(:email, :invalid)]
+    end
   end
 end

--- a/spec/specs/phone_spec.rb
+++ b/spec/specs/phone_spec.rb
@@ -5,43 +5,53 @@ describe "Phone Validation" do
   it 'should validate format of phone with ###-###-####' do
     model = Models::PhoneValidatorModel.new
     model.phone = '999-999-9999'
-    model.valid?.should == true
+    model.valid?.should be(true)
     model.should have(0).errors
   end
 
   it 'should validate format of phone with ##########' do
     model = Models::PhoneValidatorModel.new
     model.phone = '9999999999'
-    model.valid?.should == true
+    model.valid?.should be(true)
     model.should have(0).errors
   end
 
   it 'should validate format of phone with ###.###.####' do
     model = Models::PhoneValidatorModel.new
     model.phone = '999.999.9999'
-    model.valid?.should == true
+    model.valid?.should be(true)
     model.should have(0).errors
   end
 
   it 'should validate format of phone with ### ### ####' do
     model = Models::PhoneValidatorModel.new
     model.phone = '999 999 9999'
-    model.valid?.should == true
+    model.valid?.should be(true)
     model.should have(0).errors
   end
 
   it 'should validate format of phone with (###) ###-####' do
     model = Models::PhoneValidatorModel.new
     model.phone = '(999) 999-9999'
-    model.valid?.should == true
+    model.valid?.should be(true)
     model.should have(0).errors
   end
-  
-  it 'should validate format of phone' do
-    model = Models::PhoneValidatorModel.new
-    model.phone = '999'
-    model.valid?.should == false
-    model.should have(1).errors
-  end
 
+  describe "for invalid formats" do
+    let(:model) do
+      Models::PhoneValidatorModel.new.tap do |m|
+        m.phone = '999'
+      end
+    end
+
+    it "rejects invalid formats" do
+      model.valid?.should be(false)
+      model.should have(1).errors
+    end
+
+    it "generates an error message of type invalid" do
+      model.valid?.should be(false)
+      model.errors[:phone].should == [model.errors.generate_message(:phone, :invalid)]
+    end
+  end
 end

--- a/spec/specs/respond_to_spec.rb
+++ b/spec/specs/respond_to_spec.rb
@@ -7,17 +7,27 @@ describe "Respond To Validation" do
     model.global_condition = true
     model.local_condition = true
 
-    model.valid?.should == true
+    model.valid?.should be(true)
     model.should have(0).errors
   end
 
-  it "does not respond_to?" do
-    model = Models::RespondToValidatorModel.new
-    model.responder = 42
-    model.global_condition = true
-    model.local_condition = true
+  describe "when does not respond_to?" do
+    let(:model) do
+      Models::RespondToValidatorModel.new.tap do |m|
+        m.responder        = 42
+        m.global_condition = true
+        m.local_condition  = true
+      end
+    end
 
-    model.valid?.should == false
-    model.should have(1).errors
+    it "rejects the responder" do
+      model.valid?.should be(false)
+      model.should have(1).errors
+    end
+
+    it "generates an error message of type invalid" do
+      model.valid?.should be(false)
+      model.errors[:responder].should == [model.errors.generate_message(:responder, :invalid)]
+    end
   end
 end

--- a/spec/specs/url_spec.rb
+++ b/spec/specs/url_spec.rb
@@ -8,10 +8,21 @@ describe "Url Validation" do
     model.should have(0).errors
   end
 
-  it "rejected invalid urls" do
-    model = Models::UrlValidatorModel.new
-    model.url = 'http://^^^^.fr'
-    model.valid?.should be(false)
-    model.should have(1).errors
+  describe "for invalid emails" do
+    let(:model) do
+      Models::UrlValidatorModel.new.tap do |m|
+        m.url = 'http://^^^^.fr'
+      end
+    end
+
+    it "rejects invalid emails" do
+      model.valid?.should be(false)
+      model.should have(1).errors
+    end
+
+    it "generates an error message of type invalid" do
+      model.valid?.should be(false)
+      model.errors[:url].should == [model.errors.generate_message(:url, :invalid)]
+    end
   end
 end


### PR DESCRIPTION
Hi,

I've change how to add errors in each validator to use the api defined in activemodel with this we get i18n support for free.

I've used the same error message that you used, this error message is set by default. Maybe for some validator you could define specific types of errors message and a i18n key too:

{ :errors =>
    :messages =>
       :not_respond_to => not respond to %{method}
}
