### PR TITLE
Slug validation raises NoMethodError when running against no slug

### DIFF
--- a/lib/active_model/validations/slug_validator.rb
+++ b/lib/active_model/validations/slug_validator.rb
@@ -2,7 +2,7 @@ module ActiveModel
   module Validations
     class SlugValidator < EachValidator
       def validate_each(record, attribute, value)
-        unless value == value.parameterize
+        if value && value != value.parameterize
           record.errors.add(attribute)
         end
       end


### PR DESCRIPTION
When you try to check if an empty model is `valid?`, it will raise a NoMethodError and not return false. This fix will return the call to `valid?` as false if the value isn't present or valid. Calling parameterize on the nil value raises this error, which the whole point is to check if its valid.

To reproduce:

```
list = List.new
list.valid?
```
