### PR TITLE
Implemented 'old-school' validators

### DIFF
--- a/lib/activevalidators.rb
+++ b/lib/activevalidators.rb
@@ -3,14 +3,28 @@ require 'active_model'
 require 'active_record'
 require 'active_support/all'
 require 'active_model/validations'
-#Eager autoload the library's validators into AR::Validations
+
 module ActiveModel
   module Validations
     extend ActiveSupport::Autoload
 
-    validators = ['Email','Url','RespondTo','Phone','Slug','Ip','CreditCard','Date','Password','Twitter']
-    validators.each do |validator_name|
-      autoload (validator_name+'Validator').to_sym
+    def self.activevalidators
+      ['Email','Url','RespondTo','Phone','Slug','Ip','CreditCard','Date','Password','Twitter']
+    end
+
+    #Eager autoload the library's validators into AR::Validations
+    activevalidators.each do |validator_name|
+      autoload validator_name+'Validator'
+    end
+
+    #Defines methods like validates_credit_card
+    module HelperMethods
+      ActiveModel::Validations.activevalidators.map(&:underscore).each do |validator|
+        define_method('validates_'+validator) do |*fields|
+          options ||= (fields.delete fields.find { |f| f.kind_of? Hash}) || true
+          validates *fields, validator => options
+        end
+      end
     end
   end
 end

--- a/spec/activevalidators_spec.rb
+++ b/spec/activevalidators_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe "A class with active validators included" do
+  subject { TestRecord }
+
+  validators = ['Email','Url','RespondTo','Phone','Slug','Ip','CreditCard','Date','Password','Twitter'].map(&:underscore)
+  validators.each do |validator|
+    describe ".validates_#{validator}" do
+      it "is defined" do
+        subject.should respond_to("validates_#{validator}")
+      end
+
+      context "when it doesn't receive a hash with options" do
+        it "calls validates #{validator} => true" do
+          subject.should_receive('validates').with hash_including(validator => true)
+          subject.send("validates_#{validator}")
+        end
+
+        it "calls 'validates *attributes, #{validator} => true' when fed with attributes" do
+          subject.should_receive('validates').with(:attr1, :attr2, validator => true)
+          subject.send("validates_#{validator}", :attr1, :attr2)
+        end
+      end
+
+      context "when it receives a hash with options" do
+        it "calls validates #{validator} => options" do
+          subject.should_receive('validates').with hash_including(validator => {:options => :blah})
+          subject.send("validates_#{validator}", :options => :blah)
+        end
+
+        it "calls 'validates *attributes, #{validator} => options' when fed with attributes" do
+          subject.should_receive('validates').with(:attr1, :attr2, validator => {:options => :blah})
+          subject.send("validates_#{validator}", :attr1, :attr2, :options => :blah)
+        end
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
As Cesario pointed out, some people still prefer doing
<code>validates_credit_card :credit_card</code>

Instead of
<code>validates :credit_card, :credit_card => true</code>

I've implemented a way to define those "old-school" methods dynamically, as soon as ActiveModel::Validations is included, using the same mechanism rails uses to define, for example, <code>validates_presence_of</code>

Many specs are included to test if this behavior works nicely with all validators
