### PR TITLE
Fixed Ruby 1.8.7 support

### DIFF
--- a/lib/activevalidators.rb
+++ b/lib/activevalidators.rb
@@ -22,7 +22,8 @@ module ActiveModel
       ActiveModel::Validations.activevalidators.map(&:underscore).each do |validator|
         define_method('validates_'+validator) do |*fields|
           options ||= (fields.delete fields.find { |f| f.kind_of? Hash}) || true
-          validates *fields, validator => options
+          args = fields.push({ validator => options })
+          validates(*args)
         end
       end
     end


### PR DESCRIPTION
As pointed out by @cesario, 1ac6fae12bb7cd1f2000bda68b9417ce1f267fd6 broke 1.8.7 support, because of a few differences regarding splatted arguments.

This commit fixes it by splatting all arguments at once
