### PR TITLE
check value#blank? in validations

### DIFF
--- a/lib/active_model/validations/credit_card_validator.rb
+++ b/lib/active_model/validations/credit_card_validator.rb
@@ -4,7 +4,7 @@ module ActiveModel
     class CreditCardValidator < EachValidator
       def validate_each(record, attribute, value)
         type = options.fetch(:type, :any)
-        record.errors.add(attribute) unless Luhn.valid?(type, sanitize_card(value))
+        record.errors.add(attribute) if value.blank? || !Luhn.valid?(type, sanitize_card(value))
       end
 
       def sanitize_card(value)

--- a/lib/active_model/validations/ip_validator.rb
+++ b/lib/active_model/validations/ip_validator.rb
@@ -2,7 +2,7 @@ module ActiveModel
   module Validations
     class IpValidator < EachValidator
       def validate_each(record, attribute, value)
-        record.errors.add(attribute) unless regex.match(value)
+        record.errors.add(attribute) if value.blank? || !regex.match(value)
       end
 
       def check_validity!

--- a/lib/active_model/validations/phone_validator.rb
+++ b/lib/active_model/validations/phone_validator.rb
@@ -4,9 +4,7 @@ module ActiveModel
       def validate_each(record, attribute, value)
         @value = value
         @formats = PhoneValidator.known_formats[options[:country]] || PhoneValidator.known_formats[:us]
-        unless matches_any?
-          record.errors.add(attribute)
-        end
+        record.errors.add(attribute) if value.blank? || !matches_any?
       end
 
       def self.known_formats

--- a/lib/active_model/validations/postal_code_validator.rb
+++ b/lib/active_model/validations/postal_code_validator.rb
@@ -6,7 +6,7 @@ module ActiveModel
         country = options[:country] || :us
         @formats = PostalCodeValidator.known_formats[country]
         raise "No known postal code formats for country #{country}" unless @formats
-        record.errors.add(attribute) unless matches_any?
+        record.errors.add(attribute) if value.blank? || !matches_any?
       end
 
       def self.known_formats

--- a/lib/active_model/validations/tracking_number_validator.rb
+++ b/lib/active_model/validations/tracking_number_validator.rb
@@ -6,7 +6,7 @@ module ActiveModel
         raise "Carrier option required" unless carrier
         method = "valid_#{carrier.to_s}?"
         raise "Tracking number validation not supported for carrier #{carrier}" unless self.respond_to?(method)
-        record.errors.add(attribute) unless self.send(method, value)
+        record.errors.add(attribute) if value.blank? || !self.send(method, value) 
       end
 
       # UPS:


### PR DESCRIPTION
for example without this patch:

```
class User < ActiveRecord::Base
   validates :post_code, :post_code => true
end

User.new.valid? 
```
# =>

```
NoMethodError: undefined method `match' for nil:NilClass
    from /usr/lib/ruby/gems/1.9.1/gems/activesupport-3.1.0/lib/active_support/whiny_nil.rb:48:in `method_missing'
    from /home/guten/dev/src/activevalidators/lib/active_model/validations/postal_code_validator.rb:22:in `block in matches_any?'
    from /home/guten/dev/src/activevalidators/lib/active_model/validations/postal_code_validator.rb:22:in `each'
    from /home/guten/dev/src/activevalidators/lib/active_model/validations/postal_code_validator.rb:22:in `detect'
    from /home/guten/dev/src/activevalidators/lib/active_model/validations/postal_code_validator.rb:22:in `matches_any?'
    from /home/guten/dev/src/activevalidators/lib/active_model/validations/postal_code_validator.rb:10:in `validate_each'
    from /home/guten/dev/src/activemodel-3.1.0/lib/active_model/validator.rb:155:in `block in validate'
    from /home/guten/dev/src/activemodel-3.1.0/lib/active_model/validator.rb:151:in `each'
    from /home/guten/dev/src/activemodel-3.1.0/lib/active_model/validator.rb:151:in `validate'
```
