### PR TITLE
Properly handle checksums of '0' in usps mod10.

### DIFF
--- a/lib/active_model/validations/tracking_number_validator.rb
+++ b/lib/active_model/validations/tracking_number_validator.rb
@@ -44,7 +44,7 @@ module ActiveModel
 
       MOD10_WEIGHTS = [3,1]
       def usps_mod10(chars)
-        10 - weighted_sum(chars.reverse, MOD10_WEIGHTS) % 10
+        (10 - weighted_sum(chars.reverse, MOD10_WEIGHTS) % 10) % 10
       end
 
       MOD11_WEIGHTS = [8,6,4,2,3,5,9,7]

--- a/test/validations/tracking_number_test.rb
+++ b/test/validations/tracking_number_test.rb
@@ -68,6 +68,10 @@ describe "Tracking Number Validation" do
         assert_valid_tracking_number({:carrier => :usps}, '71123456789123456787')
       end
 
+      it '20 character USS128 tracking number with valid MOD10 check digit ending in 0' do
+        assert_valid_tracking_number({:carrier => :usps}, '03110240000115809160')
+      end
+
       it '22 character USS128 tracking number with valid MOD10 check digit' do
         assert_valid_tracking_number({:carrier => :usps}, '9171969010756003077385')
       end


### PR DESCRIPTION
Current implementation returns 10, which does not equal 0.
