### PR TITLE
Remove active_record dependency

### DIFF
--- a/activevalidators.gemspec
+++ b/activevalidators.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "bundler"
   s.add_development_dependency "minitest"
   s.add_dependency 'rake'          , '>= 0.8.7'
-  s.add_dependency 'activerecord'  , '>= 3.0.0'
   s.add_dependency 'activemodel'   , '>= 3.0.0'
   s.add_dependency 'mail'
   s.add_dependency 'date_validator'


### PR DESCRIPTION
This rather awesome library doesn't use active_record at all anywhere.
No reason to have an active_record dependency. All tests still pass.
