### PR TITLE
replace custom url regexp with URI.regexp

### DIFF
--- a/lib/active_model/validations/url_validator.rb
+++ b/lib/active_model/validations/url_validator.rb
@@ -1,15 +1,84 @@
+require 'uri'
+
 module ActiveModel
   module Validations
+
+    # Public: Uses `URI.regexp` to validate URLs, by default only allows
+    # the http and https protocols.
+    #
+    # Examples
+    #
+    #    validates :url, :url => true
+    #    # => only allow http, https
+    #
+    #    validates :url, :url => %w{http https ftp ftps}
+    #    # => allow http, https, ftp and ftps
+    #
     class UrlValidator < EachValidator
-      class << self
-        attr_accessor :url_regex
+
+      # Public: Creates a new instance, overrides `:protocols` if either
+      # `:with` or `:in` are defined, to allow for shortcut setters.
+      #
+      # Examples:
+      #
+      #     validates :url, :url => { :protocols => %w{http https ftp} }
+      #     # => accepts http, https and ftp URLs
+      #
+      #     validates :url, :url => 'https'
+      #     # => accepts only https URLs (shortcut form of above)
+      #
+      #     validates :url, :url => true
+      #     # => by default allows only http and https
+      #
+      # Raises an ArgumentError if the array with the allowed protocols
+      # is empty.
+      #
+      # Returns a new instance.
+      def initialize(options)
+        options[:protocols] ||= options.delete(:protocol) || options.delete(:with) || options.delete(:in)
+        super
       end
-      # Damn complex regex found on GWave https://wave.google.com/wave/?pli=1#restored:wave:googlewave.com!w%252BsFbGJUukA
-      self.url_regex = /^(?#Protocol)(?:(?:ht|f)tp(?:s?)\:\/\/|~\/|\/)?(?#Username:Password)(?:\w+:\w+@)?(?#Subdomains)(?:(?:[-\w]+\.)+(?#TopLevel Domains)(?:com|org|net|gov|mil|biz|info|mobi|name|aero|jobs|museum|travel|[a-z]{2}))(?#Port)(?::[\d]{1,5})?(?#Directories)(?:(?:(?:\/(?:[-\w~!$+|.,=]|%[a-f\d]{2})+)+|\/)+|\?|#)?(?#Query)(?:(?:\?(?:[-\w~!$+|.,*:]|%[a-f\d{2}])+=?(?:[-\w~!$+|.,*:=]|%[a-f\d]{2})*)(?:&(?:[-\w~!$+|.,*:]|%[a-f\d{2}])+=?(?:[-\w~!$+|.,*:=]|%[a-f\d]{2})*)*)*(?#Anchor)(?:#(?:[-\w~!$+|.,*:=]|%[a-f\d]{2})*)?$/
+
+      # Internal: Ensures that at least one protocol is defined. If the protocols
+      # are empty it throws an ArgumentError.
+      #
+      # Raises ArgumentError if protocols is empty.
+      #
+      # Returns nothing.
+      def check_validity!
+        raise ArgumentError, "At least one URI protocol is required" if protocols.empty?
+      end
+
+      # Internal: Returns an array of protocols to use with the URI regexp.
+      # The default protocols are `http` and `https`.
+      #
+      # Returns the Array with the allowed protocols.
+      def protocols
+        Array.wrap(options[:protocols] || %w{http https})
+      end
+
+      # Internal: Constructs the regular expression to check
+      # the URI for the configured protocols.
+      #
+      # Returns the Regexp.
+      def uri_regexp
+        @uri_regexp ||= URI.regexp(protocols)
+      end
+
+      # Internal: Tries to convert supplied string into URI,
+      # if not possible returns nil => invalid URI.
+      #
+      # Returns the URI or nil.
+      def as_uri(value)
+        URI.parse(value.to_s) rescue nil if value.present?
+      end
+
+      # Public: Validate URL, if it fails adds an error.
+      #
+      # Returns nothing.
       def validate_each(record, attribute, value)
-        unless value =~ self.class.url_regex
-          record.errors.add(attribute)
-        end
+        uri = as_uri(value)
+        record.errors.add(attribute) unless uri && value.to_s =~ uri_regexp
       end
     end
   end

--- a/test/validations/url_test.rb
+++ b/test/validations/url_test.rb
@@ -7,6 +7,12 @@ describe "Url Validation" do
     TestRecord.new
   end
 
+  def build_ftp_record
+    TestRecord.reset_callbacks(:validate)
+    TestRecord.validates :url, :url => 'ftp'
+    TestRecord.new
+  end
+
   describe "valid urls" do
     it "accepts urls without port number" do
       subject = build_url_record
@@ -28,9 +34,17 @@ describe "Url Validation" do
       subject.valid?.must_equal true
       subject.errors.size.must_equal 0
     end
+
     it "accepts valid SSL urls" do
       subject = build_url_record
       subject.url = 'https://www.verrot.fr'
+      subject.valid?.must_equal true
+      subject.errors.size.must_equal 0
+    end
+
+    it "accepts ftp if defined" do
+      subject = build_ftp_record
+      subject.url = 'ftp://ftp.verrot.fr'
       subject.valid?.must_equal true
       subject.errors.size.must_equal 0
     end
@@ -49,6 +63,27 @@ describe "Url Validation" do
       subject.url = 'http://^^^^.fr'
       subject.valid?.must_equal false
       subject.errors[:url].include?(subject.errors.generate_message(:url, :invalid)).must_equal true
+    end
+
+    it "rejects nil urls" do
+      subject = build_url_record
+      subject.url = nil
+      subject.valid?.must_equal false
+      subject.errors.size.must_equal 1
+    end
+
+    it "rejects empty urls" do
+      subject = build_url_record
+      subject.url = ''
+      subject.valid?.must_equal false
+      subject.errors.size.must_equal 1
+    end
+
+    it "rejects invalid protocols" do
+      subject = build_url_record
+      subject.url = 'ftp://ftp.verrot.fr'
+      subject.valid?.must_equal false
+      subject.errors.size.must_equal 1
     end
   end
 end


### PR DESCRIPTION
Thanks for the nice collection of ActiveModel validators.

I've refactored the UriValidator to make use of URI.regexp to verify URLs. This allows for further customizations, like only allowing certain protocols, or creating a strict mode which does not allow userinfo, or custom ports.

The refactord UriValidator can take an array as argument which is the list of allowed protocols, the default is to only allow `http` and `https` URLs.

``` ruby
  validates :url, :url => true
  # => only allows http, https

  validates :url, :url => %w{ftp ftps}
  # => only allows ftp, ftps
```

Tried to add documentation to all methods (tomdoc) and I've added a few tests (empty URLs, protocols) - the existing test suite works as expected. So unless somebody is using schemes other than http/https the refactored UriValidator works the same as before.
