### PR TITLE
More postal code formats

### DIFF
--- a/lib/active_model/validations/postal_code_validator.rb
+++ b/lib/active_model/validations/postal_code_validator.rb
@@ -84,7 +84,7 @@ module ActiveModel
       private
 
       def self.regexp_from(format)
-        Regexp.new "^"+(Regexp.escape format).gsub('/[@#]/', '@' => '[[:alpha:]]', '#' => '\d')+"$"
+        Regexp.new "^"+(Regexp.escape format).gsub(/[@#]/, '@' => '[[:alpha:]]', '#' => 'd')+"$"
       end
     end
   end


### PR DESCRIPTION
Hi, i have add more postal code formats by geonames.org
They now accepts alphabetical characters by '@' code.
