### PR TITLE
Email validator refactored

### DIFF
--- a/lib/active_model/validations/email_validator.rb
+++ b/lib/active_model/validations/email_validator.rb
@@ -2,24 +2,29 @@ require 'mail'
 module ActiveModel
   module Validations
     class EmailValidator < EachValidator
-      EMAIL_REGEXP = %r{\A[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}\z}
-
-      def validate_each(record,attribute,value)
-        opts = options.dup
-        opts[:strict] ||= false
-
+      def validate_each(record, attribute, value)
+        # takes from: https://github.com/hallelujah/valid_email
         begin
-          address = Mail::Address.new(value)
-          valid   = address.domain && 
-                    value.include?(address.address) &&
-                    ( 
-                      !opts[:strict] || 
-                      address.domain.match(EMAIL_REGEXP) 
-                    )
-        rescue Mail::Field::ParseError
+          mail = Mail::Address.new(value)
+          # We must check that value contains a domain and that value is an email address
+          valid = mail.domain && value.include?(mail.address)
+
+          if options[:only_address]
+            # We need to dig into treetop
+            # A valid domain must have dot_atom_text elements size > 1
+            # user@localhost is excluded
+            # treetop must respond to domain
+            # We exclude valid email values like <user@localhost.com>
+            # Hence we use m.__send__(tree).domain
+            tree = mail.__send__(:tree)
+            valid &&= (tree.domain.dot_atom_text.elements.size > 1)
+          else
+            valid &&= (mail.domain.split('.').length > 1)
+          end
+        rescue Exception => e
           valid = false
         end
-        record.errors.add(attribute) unless valid
+        record.errors.add attribute, (options[:message]) unless valid
       end
     end
   end

--- a/test/validations/email_test.rb
+++ b/test/validations/email_test.rb
@@ -2,7 +2,7 @@ require 'test_helper.rb'
 
 describe "Email Validation" do
   describe "strict: true" do
-    
+
     it "accepts valid emails" do
       subject = build_email_record({:email => 'franck@verrot.fr'}, {:strict => true})
       subject.valid?.must_equal true
@@ -14,60 +14,60 @@ describe "Email Validation" do
       subject.valid?.must_equal true
       subject.errors.size.must_equal 0
     end
-    
+
     it "accepts complete emails" do
       subject = build_email_record({:email => 'Mikel Lindsaar (My email address) <mikel@test.lindsaar.net>'}, {:strict => true})
       subject.valid?.must_equal true
       subject.errors.size.must_equal 0
     end
-    
+
     it "accepts complete emails" do
       subject = build_email_record({:email => 'franck@verrotfr'}, {:strict => true})
       subject.valid?.must_equal false
       subject.errors.size.must_equal 1
     end
   end
-  
+
   describe "strict: false (default)" do
     it "accepts valid emails" do
       subject = build_email_record :email => 'franck@verrot.fr'
       subject.valid?.must_equal true
       subject.errors.size.must_equal 0
     end
-      
+
     it "accepts valid emails" do
       subject = build_email_record :email => 'franck@edu.verrot-gouv.fr'
       subject.valid?.must_equal true
       subject.errors.size.must_equal 0
     end
-      
+
     it "accepts complete emails" do
       subject = build_email_record :email => 'Mikel Lindsaar (My email address) <mikel@test.lindsaar.net>'
       subject.valid?.must_equal true
       subject.errors.size.must_equal 0
     end
-    
+
     it "accepts complete emails" do
       subject = build_email_record :email => 'franck@verrotfr'
-      subject.valid?.must_equal true
+      subject.valid?.must_equal false
       subject.errors.size.must_equal 0
     end
   end
-  
+
   describe "for invalid emails" do
     it "rejects invalid emails" do
       subject = build_email_record :email => 'franck.fr'
       subject.valid?.must_equal false
       subject.errors.size.must_equal 1
     end
-      
+
     it 'rejects local emails' do
       subject = build_email_record :email => 'franck.fr'
       subject.email = 'franck'
       subject.valid?.must_equal false
       subject.errors.size.must_equal 1
     end
-      
+
     it 'generates an error message of type invalid' do
       subject = build_email_record :email => 'franck.fr'
       subject.valid?.must_equal false


### PR DESCRIPTION
Accepts only full email address and full email address with display name.

:strict changed to :only_address due to :strict is registered word
