### PR TITLE
fix email validator

### DIFF
--- a/test/validations/email_test.rb
+++ b/test/validations/email_test.rb
@@ -50,7 +50,7 @@ describe "Email Validation" do
     it "accepts complete emails" do
       subject = build_email_record :email => 'franck@verrotfr'
       subject.valid?.must_equal false
-      subject.errors.size.must_equal 0
+      subject.errors.size.must_equal 1
     end
   end
 


### PR DESCRIPTION
email@domain without suffix is now invalid
