### PR TITLE
Add option to email validator to allow quick validation via a lambda function

### DIFF
--- a/lib/active_model/validations/email_validator.rb
+++ b/lib/active_model/validations/email_validator.rb
@@ -2,6 +2,10 @@ require 'mail'
 module ActiveModel
   module Validations
     class EmailValidator < EachValidator
+      def check_validity!
+        raise ArgumentError, "Not a callable object #{options[:with].inspect}" unless options[:with] == nil || options[:with].respond_to?(:call)
+      end
+
       def validate_each(record, attribute, value)
         # takes from: https://github.com/hallelujah/valid_email
         begin
@@ -24,6 +28,13 @@ module ActiveModel
         rescue Exception => e
           valid = false
         end
+
+        if options[:with]
+          # technically the test suite will pass without the boolean coercion 
+          # but we know the code is safer with it in place
+          valid &&= !!options[:with].call(mail)
+        end
+
         record.errors.add attribute, (options[:message]) unless valid
       end
     end


### PR DESCRIPTION
This new feature allows you to pass a :with option to your email validator that will take any object that responds to "call" (such as a lambda, proc, or even a PORO) and use it to validate a parsed email address.

Example:

``` ruby
class MyModel < ActiveRecord::Base
   # rejects any email address with the "hotmail.com" domain
   validates :email_address, email: {with: -> email { not email.domain == "hotmail.com" }}

   # rejects any email address that doesn't have the .com TLD
   validates :email_address, email: {with: -> email { email.domain =~ /\.com^Z/ }}
end
```

FYI I used ruby 1.9 syntax in this code, I'm not sure if ActiveValidators supports 1.8.x (the travis.yml file seems to suggest "no") but if so let me know...

Possible topics of discussion:
1. is there a better option name than :with ?
2. what should the behavior be when the callable returns a "falsy" value which evaluates to true? (such as a blank string)
3. I18n concerns with respect to the message?
4. ????
