### PR TITLE
Add HexColor validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Exhaustive list of supported validators and their implementation:
 * `twitter` : based on a regular expression
 * `url`   : based on a regular expression
 * `barcode`   : based on known formats (:ean13 only for now)
+* `hex_color` : based on a regular expression
 
 ## Todo
 

--- a/lib/active_model/validations/hex_color_validator.rb
+++ b/lib/active_model/validations/hex_color_validator.rb
@@ -1,0 +1,11 @@
+module ActiveModel
+  module Validations
+    class HexColorValidator < EachValidator
+      def validate_each(record, attribute, value)
+        unless value =~ /\A(\h{3}){,2}\z/
+          record.errors.add(attribute)
+        end
+      end
+    end
+  end
+end

--- a/lib/activevalidators.rb
+++ b/lib/activevalidators.rb
@@ -5,7 +5,7 @@ require 'active_validators/one_nine_shims/one_nine_string'
 
 module ActiveValidators
   def self.activevalidators
-    %w(email url respond_to phone slug ip credit_card date password twitter postal_code tracking_number siren ssn sin nino barcode date)
+    %w(email url respond_to phone slug ip credit_card date password twitter postal_code tracking_number siren ssn sin nino barcode date hex_color)
   end
 
   # Require each validator independently or just pass :all

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,7 +14,8 @@ class TestRecord
   include ActiveModel::Validations
   attr_accessor :ip, :url, :slug, :responder, :global_condition,
     :local_condition, :phone, :email, :card, :password, :twitter_username,
-    :postal_code, :carrier, :tracking_number, :start_date, :end_date, :siren, :ssn, :sin, :nino, :barcode
+    :postal_code, :carrier, :tracking_number, :start_date, :end_date, :siren, :ssn, :sin, :nino, :barcode,
+    :text_color
 
   def initialize(attrs = {})
     attrs.each_pair { |k,v| send("#{k}=", v) }

--- a/test/validations/hex_color_test.rb
+++ b/test/validations/hex_color_test.rb
@@ -1,0 +1,55 @@
+require 'test_helper'
+ActiveValidators.activate(:hex_color)
+
+describe "Hex-Color Validation" do
+  let(:invalid_message) { subject.errors.generate_message(:text_color, :invalid) }
+
+  subject { TestRecord.new }
+
+  before do
+    TestRecord.reset_callbacks(:validate)
+    TestRecord.validates :text_color, :hex_color => true
+  end
+
+  it "accepts blank value" do
+    subject.text_color = ''
+
+    subject.must_be :valid?
+    subject.errors.must_be :empty?
+  end
+
+  it "accepts 3 hex characters" do
+    subject.text_color = 'abc'
+
+    subject.must_be :valid?
+    subject.errors.must_be :empty?
+  end
+
+  it "accepts 6 hex characters" do
+    subject.text_color = 'abc012'
+
+    subject.must_be :valid?
+    subject.errors.must_be :empty?
+  end
+
+  it "rejects non-hex characters" do
+    subject.text_color = 'efg345'
+
+    subject.must_be :invalid?
+    subject.errors[:text_color].must_include invalid_message
+  end
+
+  it "rejects too few characters" do
+    subject.text_color = 'ef'
+
+    subject.must_be :invalid?
+    subject.errors[:text_color].must_include invalid_message
+  end
+
+  it "rejects too many characters" do
+    subject.text_color = 'efab001'
+
+    subject.must_be :invalid?
+    subject.errors[:text_color].must_include invalid_message
+  end
+end


### PR DESCRIPTION
This validator is useful for ensuring certain attributes are valid hex-color values.

[Source](http://viget.com/extend/seven-useful-activemodel-validators)
