### PR TITLE
Providing {:type => :usa_ssn} is deprecated and will be removed in the future. Please use `:ssn => true` instead.

### DIFF
--- a/lib/active_model/validations/ssn_validator.rb
+++ b/lib/active_model/validations/ssn_validator.rb
@@ -2,16 +2,18 @@ module ActiveModel
   module Validations
     class SsnValidator < EachValidator
       def validate_each(record, attribute, value)
-        type = options.fetch(:type, :usa_ssn)                                                       # :usa_ssn is default.
-        record.errors.add(attribute) if value.blank? || !SsnValidatorGeneral.valid?(type, value)
+        record.errors.add(attribute) if value.blank? || !SsnValidatorGeneral.valid?(options, value)
       end
     end
 
+    # <b>DEPRECATED:</b> Please use <tt>:ssn => true</tt> instead.
     class SsnValidatorGeneral
-      def self.valid?(type, value)
-        if type == :usa_ssn
-          SsnValidatorUSA.new(value).valid?
+      def self.valid?(options, value)
+        if options[:type] == :usa_ssn
+          warn "[DEPRECATION] providing {:type => :usa_ssn} is deprecated and will be removed in the future. Please use `:ssn => true` instead."
         end
+
+        SsnValidatorUSA.new(value).valid?
       end
     end
 

--- a/test/validations/ssn_test.rb
+++ b/test/validations/ssn_test.rb
@@ -5,45 +5,45 @@ describe "SSN validations" do
   describe "USA ssn" do
     describe "for invalid" do
       it "rejects empty ssn" do
-        subject = build_ssn_record({:ssn => ''}, {:type => :usa_ssn})
+        subject = build_ssn_record({:ssn => ''}, true)
         subject.valid?.must_equal false
       end
 
       it "rejects ssn when it doesn't consist of numbers" do
-        subject = build_ssn_record({:ssn => 'aaabbcccc'}, {:type => :usa_ssn})
+        subject = build_ssn_record({:ssn => 'aaabbcccc'}, true)
         subject.valid?.must_equal false
       end
 
       it "rejects ssn when the first group of digits is 000" do
-        subject = build_ssn_record({:ssn => '000112222'}, {:type => :usa_ssn})
+        subject = build_ssn_record({:ssn => '000112222'}, true)
         subject.valid?.must_equal false
       end
 
       it "rejects ssn when the first group of digits is 666" do
-        subject = build_ssn_record({:ssn => '666112222'}, {:type => :usa_ssn})
+        subject = build_ssn_record({:ssn => '666112222'}, true)
         subject.valid?.must_equal false
       end
 
       (900..999).each do |first_group_num|
         it "rejects ssn when the first group of digits is #{first_group_num}" do
-          subject = build_ssn_record({:ssn => "#{first_group_num}112222"}, {:type => :usa_ssn})
+          subject = build_ssn_record({:ssn => "#{first_group_num}112222"}, true)
           subject.valid?.must_equal false
         end
       end
 
       it "reject ssn when the second group of digits is 00" do
-        subject = build_ssn_record({:ssn => "555002222"}, {:type => :usa_ssn})
+        subject = build_ssn_record({:ssn => "555002222"}, true)
         subject.valid?.must_equal false
       end
 
       it "reject ssn when the third group of digits is 0000" do
-        subject = build_ssn_record({:ssn => "555660000"}, {:type => :usa_ssn})
+        subject = build_ssn_record({:ssn => "555660000"}, true)
         subject.valid?.must_equal false
       end
 
       (987654320..987654329).each do |reserved_ssn|
         it "rejects reserved ssn such as #{reserved_ssn}" do
-          subject = build_ssn_record({:ssn => "#{reserved_ssn}"}, {:type => :usa_ssn})
+          subject = build_ssn_record({:ssn => "#{reserved_ssn}"}, true)
           subject.valid?.must_equal false
         end
       end


### PR DESCRIPTION
I made `{:type => :usa_ssn}` deprecated for SSN validation, because such additional logic is overhead because I don't know countries with same identification name (ssn). I think that we need to have this deprecation message at least for one release and then I'll finally remove the code which'll make code cleaner.
