### PR TITLE
Add Regexp validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Exhaustive list of supported validators and their implementation:
 * `url`   : based on a regular expression
 * `barcode`   : based on known formats (:ean13 only for now)
 * `hex_color` : based on a regular expression
+* `regexp` : uses Ruby's [`Regexp.compile`](http://www.ruby-doc.org/core-2.1.1/Regexp.html#method-c-new) method
 
 ## Todo
 

--- a/lib/active_model/validations/regexp_validator.rb
+++ b/lib/active_model/validations/regexp_validator.rb
@@ -1,0 +1,22 @@
+module ActiveModel
+  module Validations
+    class RegexpValidator < EachValidator
+      def validate_each(record, attribute, value)
+        unless valid_regexp?(value)
+          record.errors.add(attribute)
+        end
+      end
+
+
+      private
+
+      def valid_regexp?(value)
+        Regexp.compile(value.to_s)
+        true
+
+      rescue RegexpError
+        false
+      end
+    end
+  end
+end

--- a/lib/activevalidators.rb
+++ b/lib/activevalidators.rb
@@ -5,7 +5,7 @@ require 'active_validators/one_nine_shims/one_nine_string'
 
 module ActiveValidators
   def self.activevalidators
-    %w(email url respond_to phone slug ip credit_card date password twitter postal_code tracking_number siren ssn sin nino barcode date hex_color)
+    %w(email url respond_to phone slug ip credit_card date password twitter postal_code tracking_number siren ssn sin nino barcode date hex_color regexp)
   end
 
   # Require each validator independently or just pass :all

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,7 +15,7 @@ class TestRecord
   attr_accessor :ip, :url, :slug, :responder, :global_condition,
     :local_condition, :phone, :email, :card, :password, :twitter_username,
     :postal_code, :carrier, :tracking_number, :start_date, :end_date, :siren, :ssn, :sin, :nino, :barcode,
-    :text_color
+    :text_color, :redirect_rule
 
   def initialize(attrs = {})
     attrs.each_pair { |k,v| send("#{k}=", v) }

--- a/test/validations/regexp_test.rb
+++ b/test/validations/regexp_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+ActiveValidators.activate(:regexp)
+
+describe "Regexp Validation" do
+  let(:invalid_message) { subject.errors.generate_message(:redirect_rule, :invalid) }
+
+  subject { TestRecord.new }
+
+  before do
+    TestRecord.reset_callbacks(:validate)
+    TestRecord.validates :redirect_rule, :regexp => true
+  end
+
+  it "accepts blank value" do
+    subject.redirect_rule = ''
+
+    subject.must_be :valid?
+    subject.errors.must_be :empty?
+  end
+
+  it "rejects malformed regular expressions" do
+    subject.redirect_rule = '['
+
+    subject.must_be :invalid?
+    subject.errors[:redirect_rule].must_include invalid_message
+  end
+
+  it "allow proper regular expressions" do
+    subject.redirect_rule = '^/vanity-url(-2014)?'
+
+    subject.must_be :valid?
+    subject.errors.must_be :empty?
+  end
+
+end


### PR DESCRIPTION
The Regular Expression validator is used for ensuring validity of attributes that should be regular expressions. Common use-cases I've seen in the past include allowing redirect rules to be managed within an application.

[Source](http://viget.com/extend/seven-useful-activemodel-validators)
