### PR TITLE
credit card validation refactoring using credit_card_validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,10 @@ In your models, the gem provides new validators like `email`, or `url`:
     end
 
     class Account
-      validates :any_card,      :credit_card => true
-      validates :visa_card,     :credit_card => { :type => :visa }
-      validates :credit_card,   :credit_card => { :type => :any  }
+      validates :any_card,        :credit_card => true
+      validates :visa_card,       :credit_card => { :type => :visa }
+      validates :credit_card,     :credit_card => { :type => :any  }
+      validates :supported_card,  :credit_card => { :type => [:visa, :master_card, :amex] }
     end
 
     class Order
@@ -97,7 +98,7 @@ In your models, the gem provides new validators like `email`, or `url`:
 
 Exhaustive list of supported validators and their implementation:
 
-* `credit_card` : based on the `Luhn` algorithm
+* `credit_card` : based on the `credit_card_validations` gem
 * `date`  : based on the `DateValidator` gem
 * `email` : based on the `mail` gem
 * `ip`    : based on `Resolv::IPv[4|6]::Regex`

--- a/activevalidators.gemspec
+++ b/activevalidators.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'countries'     , '~> 0.9.3'
   s.add_dependency 'mail'
   s.add_dependency 'date_validator'
+  s.add_dependency 'credit_card_validations', '~> 1.4.5'
 
   s.files              = `git ls-files`.split("\n")
   s.test_files         = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/test/validations/credit_card_test.rb
+++ b/test/validations/credit_card_test.rb
@@ -3,31 +3,31 @@ ActiveValidators.activate(:credit_card)
 
 describe "Credit Card Validation" do
   # Here are some valid credit cards
-  VALID_CARDS =  
-  {
-    #American Express
-    :amex =>	'3400 0000 0000 009',
-    #Carte Blanche	
-    :carte_blanche => '3000 0000 0000 04',
-    #Discover	
-    :discover => '6011 0000 0000 0004',
-    #Diners Club	
-    :diners_club => '3852 0000 0232 37',
-    #enRoute	
-    :en_route => '2014 0000 0000 009',
-    #JCB	
-    :jcb => '2131 0000 0000 0008',
-    #MasterCard	
-    :master_card => '5500 0000 0000 0004',
-    #Solo	
-    :solo => '6334 0000 0000 0004',
-    #Switch	
-    :switch => '4903 0100 0000 0009',
-    #Visa	
-    :visa => '4111 1111 1111 1111',
-    #Laser	
-    :laser => '6304 1000 0000 0008'
-  }
+  VALID_CARDS =
+      {
+          #American Express
+          :amex => '3400 0000 0000 009',
+          #Carte Blanche
+          :carte_blanche => '3800 0000 0000 06',
+          #Discover
+          :discover => '6011 0000 0000 0004',
+          #Diners Club
+          :diners_club => '3852 0000 0232 37',
+          #JCB
+          :jcb => '3530 1113 3330 0000',
+          #MasterCard
+          :master_card => '5500 0000 0000 0004',
+
+          :mastercard => '5500 0000 0000 0004',
+          #Solo
+          :solo => '6334 0000 0000 0004',
+          #maestro
+          :maestro => '6759 6498 2643 8453',
+          #Visa
+          :visa => '4111 1111 1111 1111',
+          #Laser
+          :laser => '6304 1000 0000 0008'
+      }
 
   VALID_CARDS.each_pair do |card, number|
     describe "it accepts #{card} cards" do
@@ -46,6 +46,17 @@ describe "Credit Card Validation" do
     end
   end
 
+  describe "using multiple card types" do
+    it "accepts card if one of type valid" do
+      subject = build_card_record({:card => VALID_CARDS[:amex]}, {:type => [:visa, :master_card, :amex]})
+      assert card_is_valid?(subject)
+    end
+
+    it "rejects card if none of type valid" do
+      subject = build_card_record({:card => VALID_CARDS[:solo]}, {:type => [:visa, :master_card, :amex]})
+      assert card_is_invalid?(subject)
+    end
+  end
   describe "for invalid cards" do
     it "rejects invalid cards and generates an error message of type invalid" do
       subject = build_card_record :card => '99999'
@@ -55,7 +66,7 @@ describe "Credit Card Validation" do
 
   def build_card_record(attrs = {}, validator = {:type => :any})
     TestRecord.reset_callbacks(:validate)
-    TestRecord.validates :card,  :credit_card => validator
+    TestRecord.validates :card, :credit_card => validator
     TestRecord.new attrs
   end
 
@@ -69,4 +80,5 @@ describe "Credit Card Validation" do
     subject.errors.size.must_equal 1
     subject.errors[:card].include?(subject.errors.generate_message(:card, :invalid)).must_equal true
   end
+
 end


### PR DESCRIPTION
this solves #52 
- removed obsolete brands
- credit_card_validations supported brands 
- added ability to validate by multiple brands, eg type: [:amex, :visa]
- fixes luhn validation checks (not all credit card brands use lunh validation)
- more strict validation (valid lunh is not enough to detect brand)
