### PR TITLE
make country case-insensitive for postal codes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,7 @@
 # UNRELEASED
 
+  * Make country case-insensitive for postal codes
+
 # 3.2.0
 
 ## MAJOR CHANGES

--- a/lib/active_validators/active_model/validations/postal_code_validator.rb
+++ b/lib/active_validators/active_model/validations/postal_code_validator.rb
@@ -10,7 +10,7 @@ module ActiveModel
             country = 'us'
           end
         end
-        @formats = PostalCodeValidator.known_formats[country.to_s]
+        @formats = PostalCodeValidator.known_formats[country.to_s.downcase]
         raise "No known postal code formats for country #{country}" unless @formats
         record.errors.add(attribute) if value.blank? || !matches_any?
       end

--- a/test/validations/postal_code_test.rb
+++ b/test/validations/postal_code_test.rb
@@ -27,8 +27,15 @@ describe "Postal Code Validation" do
   ActiveModel::Validations::PostalCodeValidator.known_formats.each do |country, formats|
     describe "when given a :#{country} country parameter" do
       formats.each do |format|
-        it "should validate format of postal code with #{format}" do
+        it "should validate format of lowercase postal code with #{format}" do
           subject = build_postal_code_record :country => country
+          subject.postal_code = ActiveValidators::OneNineShims::OneNineString.new(format).gsub(/[@#]/, '@' => 'A', '#' => '9')
+          subject.valid?.must_equal true
+          subject.errors.size.must_equal 0
+        end
+
+        it "should validate format of upcase postal code with #{format}" do
+          subject = build_postal_code_record :country => country.upcase
           subject.postal_code = ActiveValidators::OneNineShims::OneNineString.new(format).gsub(/[@#]/, '@' => 'A', '#' => '9')
           subject.valid?.must_equal true
           subject.errors.size.must_equal 0


### PR DESCRIPTION
this supports models whose country codes are represented with mixed- or uppercase letters