### PR TITLE
update credit_card_validations

### DIFF
--- a/activevalidators.gemspec
+++ b/activevalidators.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'countries'     , '>= 0.9.3'
   s.add_dependency 'mail'
   s.add_dependency 'date_validator'
-  s.add_dependency 'credit_card_validations', '~> 1.4.5'
+  s.add_dependency 'credit_card_validations', '~> 2.0.2'
 
   s.files              = `git ls-files`.split("\n")
   s.test_files         = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/lib/active_validators/active_model/validations/credit_card_validator.rb
+++ b/lib/active_validators/active_model/validations/credit_card_validator.rb
@@ -13,16 +13,14 @@ module ActiveModel
 
         DEPRECATED_BRANDS = [
             :en_route, # belongs to Diners Club  since 1992 obsolete
-            :carte_blanche, # belongs to Diners Club ,was finally phased out by 2005
-            :switch #renamed to Maestro in 2002
+            :carte_blanche # belongs to Diners Club ,was finally phased out by 2005
         ]
 
         BRANDS_ALIASES = {
             master_card: :mastercard,
             diners_club: :diners,
             en_route: :diners,
-            carte_blanche: :diners,
-            switch: :maestro
+            carte_blanche: :diners
         }
 
         def initialize(number)


### PR DESCRIPTION
Hello, just to make things updated.
credit_card_validation.gem was updated to 2.0.0 included fixes in brand detections (new brands and old brands like switch as well ), new brands support , etc..
