### PR TITLE
postal code fixes and improvements

### DIFF
--- a/lib/active_validators/active_model/validations/postal_code_validator.rb
+++ b/lib/active_validators/active_model/validations/postal_code_validator.rb
@@ -11,7 +11,6 @@ module ActiveModel
           end
         end
         @formats = PostalCodeValidator.known_formats[country.to_s.downcase]
-        raise "No known postal code formats for country #{country}" unless @formats
         record.errors.add(attribute) if value.blank? || !matches_any?
       end
 
@@ -34,6 +33,7 @@ module ActiveModel
           'fi' => ['#####'],
           'fr' => ['#####'],
           'uk' => ['@# #@@', '@## #@@', '@@# #@@', '@@## #@@', '@#@ #@@', '@@#@ #@@'],
+          'gb' => ['@# #@@', '@## #@@', '@@# #@@', '@@## #@@', '@#@ #@@', '@@#@ #@@'],
           'gf' => ['#####'],
           'gl' => ['####'],
           'gp' => ['#####'],
@@ -57,6 +57,7 @@ module ActiveModel
           'my' => ['#####'],
           'nl' => ['#### @@', '####@@'],
           'no' => ['####'],
+          'nz' => ['####'],
           'ph' => ['####'],
           'pk' => ['#####'],
           'pl' => ['##-###', '#####'],
@@ -64,6 +65,7 @@ module ActiveModel
           'pt' => ['####', '####-###'],
           'ru' => ['######'],
           'se' => ['SE-#### ##', '#### ##', '######'],
+          'sg' => ['######'],
           'si' => ['SI- ####', 'SI-####', '####'],
           'sk' => ['### ##', '#####'],
           'sm' => ['4789#', '#'],
@@ -76,7 +78,7 @@ module ActiveModel
       end
 
       def matches_any?
-        false if @formats.nil? or not @formats.respond_to?(:detect)
+        return true if @formats.nil? or not @formats.respond_to?(:detect)
         @formats.detect { |format| @value.match(PostalCodeValidator.regexp_from format) }
       end
 

--- a/test/validations/postal_code_test.rb
+++ b/test/validations/postal_code_test.rb
@@ -44,6 +44,15 @@ describe "Postal Code Validation" do
     end
   end
 
+  describe "for a country without known formats" do
+    it "accepts anything" do
+      # aa is not in ActiveModel::Validations::PostalCodeValidator.known_formats
+      subject = build_postal_code_record :country => 'aa'
+      subject.postal_code = '999'
+      subject.valid?.must_equal true
+      subject.errors.size.must_equal 0
+    end
+  end
 
   describe "for invalid formats" do
     it "rejects invalid formats" do


### PR DESCRIPTION
1. remove exception for unknown postal code formats. in practical terms, raising an exception in this case is not useful when trying to validate the postal code of a model. since the list of known formats is not comprehensive, it's totally reasonable for a globally-used application to encounter countries that don't have known postal code formats. so when that happens, just accept whatever value was given.
2. add postal code formats for GB, NZ and SG.

though the two sets of changes are not specifically related, they're so small that it's easier to include them in one pull request than to open two separate ones. hope you don't mind.