### PR TITLE
Update credit_card_validations

### DIFF
--- a/activevalidators.gemspec
+++ b/activevalidators.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'countries'     , '>= 0.9.3'
   s.add_dependency 'mail'
   s.add_dependency 'date_validator'
-  s.add_dependency 'credit_card_validations', '~> 2.0.2'
+  s.add_dependency 'credit_card_validations', '~> 3.2.2'
 
   s.files              = `git ls-files`.split("\n")
   s.test_files         = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/test/validations/credit_card_test.rb
+++ b/test/validations/credit_card_test.rb
@@ -25,8 +25,6 @@ describe "Credit Card Validation" do
           :maestro => '6759 6498 2643 8453',
           #Visa
           :visa => '4111 1111 1111 1111',
-          #Laser
-          :laser => '6304 1000 0000 0008'
       }
 
   VALID_CARDS.each_pair do |card, number|


### PR DESCRIPTION
The currently specified version of credit_card_validations is not compatible with ActiveModel >= 5.0, so I updated to the most recent version, which is.

In order to do this, I had to remove the Laser card test, because Laser cards are no longer supported by credit_card_validations since they have been withdrawn from the market.