### PR TITLE
Don't depend on countries/global

### DIFF
--- a/lib/active_validators/active_model/validations/phone_validator.rb
+++ b/lib/active_validators/active_model/validations/phone_validator.rb
@@ -4,10 +4,9 @@ module ActiveModel
   module Validations
     class PhoneValidator < EachValidator
       def validate_each(record, attribute, value)
-        country_code = Country.new(options[:country].to_s.upcase).country_code unless options[:country].blank?
+        country_code = ISO3166::Country.new(options[:country].to_s.upcase).country_code unless options[:country].blank?
         record.errors.add(attribute, options[:message]) if value.blank? || ! (options[:country].blank? ? Phony.plausible?(value) : Phony.plausible?(value, :cc => country_code) )
       end
-
     end
   end
 end

--- a/test/validations/phone_test.rb
+++ b/test/validations/phone_test.rb
@@ -8,6 +8,19 @@ describe "Phone Validation" do
     TestRecord.new attrs
   end
 
+  describe "when a country is given" do
+    it "allows numbers matching that country" do
+      subject = build_phone_validation(country: :gb)
+      subject.phone = '+441234567890'
+      subject.valid?.must_equal true
+    end
+
+    it "does not allow numbers from other counties" do
+      subject = build_phone_validation(country: :gb)
+      subject.phone = '+19999999999'
+      subject.valid?.must_equal false
+    end
+  end
 
   describe "when no country is given" do
     it 'should validate format of phone with ###-###-####' do


### PR DESCRIPTION
By default, the countries gem will not expose Country as a top level constant (it will only do this if `countries/global` is `require`d).

This means that adding phone number validations with a given country would fail, and since (until now) there weren't any tests for validating phone numbers with specific countries, this wasn't picked up in the test suite.

This PR does two things:

- Fixes phone number validation when specifying a country
- Adds tests for validating phone numbers from a specific country