### PR TITLE
Use JRuby 2.1 with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
   - 2.1.0
-  - jruby-19mode
+  - jruby-21mode
   - ruby-head
   - jruby-head
   - rbx-2


### PR DESCRIPTION
Brings JRuby in line with MRI, and should stop build failures due to mime-types-data requiring >= 2.0