### PR TITLE
Ensure bundler installs Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,5 @@ rvm:
   - ruby-head
   - jruby-head
   - rbx-2
+before_install:
+  - gem install bundler


### PR DESCRIPTION
Not having Bundler caused the jruby-head build to fail.