### PR TITLE
Allow failure from HEAD Ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,8 @@ rvm:
   - ruby-head
   - jruby-head
   - rbx-2
+
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+    - rvm: jruby-head


### PR DESCRIPTION
This will stop the whole build being marked as failed because of failures on HEAD Rubies, which is often outside of our control and not really grounds for having the badge in the README say the build is failing.