### PR TITLE
Test deprecation warnings

### DIFF
--- a/lib/active_validators/active_model/validations/ssn_validator.rb
+++ b/lib/active_validators/active_model/validations/ssn_validator.rb
@@ -10,7 +10,7 @@ module ActiveModel
     class SsnValidatorGeneral
       def self.valid?(options, value)
         if options[:type] == :usa_ssn
-          warn "[DEPRECATION] providing {:type => :usa_ssn} is deprecated and will be removed in the future. Please use `:ssn => true` instead."
+          ActiveSupport::Deprecation.warn "providing {:type => :usa_ssn} is deprecated and will be removed in the future. Please use `:ssn => true` instead."
         end
 
         SsnValidatorUSA.new(value).valid?

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 gem 'minitest'
 require 'minitest/autorun'
 require 'minitest/mock'
+require 'active_support/test_case'
 
 # silence warnings
 old_w, $-w = $-w, false
@@ -20,4 +21,8 @@ class TestRecord
   def initialize(attrs = {})
     attrs.each_pair { |k,v| send("#{k}=", v) }
   end
+end
+
+class Minitest::Spec
+  include ActiveSupport::Testing::Deprecation
 end

--- a/test/validations/credit_card_test.rb
+++ b/test/validations/credit_card_test.rb
@@ -7,8 +7,6 @@ describe "Credit Card Validation" do
       {
           #American Express
           :amex => '3400 0000 0000 009',
-          #Carte Blanche
-          :carte_blanche => '3800 0000 0000 06',
           #Discover
           :discover => '6011 0000 0000 0004',
           #Diners Club
@@ -40,6 +38,18 @@ describe "Credit Card Validation" do
       it "using :credit_card => true" do
         subject = build_card_record({:card => number}, true)
         assert card_is_valid?(subject)
+      end
+    end
+  end
+
+  describe "carte blanche" do
+    it "is deprecated" do
+      subject = build_card_record(
+        { card: '3800 0000 0000 06' },
+        { type: :carte_blanche },
+      )
+      assert_deprecated do
+        card_is_valid?(subject)
       end
     end
   end

--- a/test/validations/ssn_test.rb
+++ b/test/validations/ssn_test.rb
@@ -50,9 +50,11 @@ describe "SSN validations" do
     end
 
     describe "for valid" do
-      it "accept ssn when it contains correct numbers" do
-        subject = build_ssn_record({:ssn => '444556666'}, {:type => :usa_ssn})
-        subject.valid?.must_equal true
+      it "supports deprecated usa_ssn syntax" do
+        assert_deprecated do
+          subject = build_ssn_record({:ssn => '444556666'}, {:type => :usa_ssn})
+          subject.valid?.must_equal true
+        end
       end
 
       it "accept ssn without type (and use by default 'usa_ssn')" do


### PR DESCRIPTION
This has the added benefit of hiding the deprecation warnings from the test output