### PR TITLE
Fix NINO array literal syntax

### DIFF
--- a/lib/active_validators/active_model/validations/nino_validator.rb
+++ b/lib/active_validators/active_model/validations/nino_validator.rb
@@ -57,12 +57,12 @@ module ActiveModel
       end
 
       def prefix_not_allocated?
-        forbidden_prefixes = %w[BG, GB, NK, KN, TN, NT, ZZ]
+        forbidden_prefixes = %w[BG GB NK KN TN NT ZZ]
         !forbidden_prefixes.include?(@prefix)
       end
 
       def prefix_not_administrative_number?
-        administrative_prefixes = %w[OO, CR, FY, MW, NC, PP, PY, PZ]
+        administrative_prefixes = %w[OO CR FY MW NC PP PY PZ]
         !administrative_prefixes.include?(@prefix)
       end
     end

--- a/test/validations/nino_test.rb
+++ b/test/validations/nino_test.rb
@@ -52,7 +52,7 @@ describe "NINO validations" do
       end
 
       it "rejects non allocated prefixes" do
-        non_allocated_prefixes = %w[bg, gb, nk, kn, tn, nt, zz]
+        non_allocated_prefixes = %w[bg gb nk kn tn nt zz]
         non_allocated_prefixes.each do |suffix|
           invalid_nino = suffix + '123456C'
           subject = build_nino_record({:nino => invalid_nino})
@@ -61,7 +61,7 @@ describe "NINO validations" do
       end
 
       it "rejects administrative numbers" do
-        administrative_numbers = %w[oo, cr, fy, mw, nc, pp, py, pz]
+        administrative_numbers = %w[oo cr fy mw nc pp py pz]
         administrative_numbers.each do |suffix|
           invalid_nino = suffix + '123456C'
           subject = build_nino_record({:nino => invalid_nino})


### PR DESCRIPTION
The commas were included in the generated array elements, so NINOs were never rejected for having unallocated or administrative prefixes. An example number that should have been rejected but wasn't is GB123456C.

Unfortunately, the tests didn't catch this mistake because they used the same incorrect syntax as the implementation. This commit fixes both the implementation and the tests.