### PR TITLE
Gem countries 2 is compatible

### DIFF
--- a/activevalidators.gemspec
+++ b/activevalidators.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'date_validator'
   s.add_dependency 'activemodel'            , '>= 3.0'
   s.add_dependency 'phony'                  , '~> 2.0'
-  s.add_dependency 'countries'              , '~> 1.2', '< 3.0'
+  s.add_dependency 'countries'              , '>= 1.2', '< 3.0'
   s.add_dependency 'credit_card_validations', '~> 3.2'
 
   s.files              = `git ls-files`.split("\n")

--- a/activevalidators.gemspec
+++ b/activevalidators.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'date_validator'
   s.add_dependency 'activemodel'            , '>= 3.0'
   s.add_dependency 'phony'                  , '~> 2.0'
-  s.add_dependency 'countries'              , '~> 1.2'
+  s.add_dependency 'countries'              , '~> 1.2', '< 3.0'
   s.add_dependency 'credit_card_validations', '~> 3.2'
 
   s.files              = `git ls-files`.split("\n")


### PR DESCRIPTION
Require only Countries version 1.x could lead to ugly dependency tree with other gems.

Countries 2.x have same compatible API