### PR TITLE
Disallow business numbers from SIN validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Exhaustive list of supported validators and their implementation:
 * `respond_to` : generic Ruby `respond_to`
 * `siren` : [SIREN](http://fr.wikipedia.org/wiki/SIREN) company numbers in France
 * `slug`  : based on `ActiveSupport::String#parameterize`
-* `sin` : Social Insurance Number (only for Canada). You may also allow permanent resident cards (such cards start with '9'): `:sin => {:country => :canada, :country_options => {allow_permanent_residents: true}}`
+* `sin` : Social Insurance Number (only for Canada). You may also allow permanent resident cards (such cards start with '9') or business numbers (such numbers start with '8'): `:sin => {:country => :canada, :country_options => {allow_permanent_residents: true, allow_business_numbers: true}}`
 * `ssn` : Social Security Number (only for USA).
 * `tracking_number`: based on a set of predefined masks
 * `twitter` : based on a regular expression

--- a/lib/active_validators/active_model/validations/sin_validator.rb
+++ b/lib/active_validators/active_model/validations/sin_validator.rb
@@ -4,44 +4,45 @@ module ActiveModel
   module Validations
     class SinValidator < EachValidator
       def validate_each(record, attribute, value)
-        country = options.fetch(:country, :canada)                                                  # :canada is default.
+        country = options.fetch(:country, :canada) # :canada is default.
         record.errors.add(attribute) if value.blank? || !SinValidatorGeneral.valid?(country, value, options)
       end
     end
 
     class SinValidatorGeneral
       def self.valid?(country, value, options)
-        if country == :canada
-          SinValidatorCanada.new(value, options).valid?
-        end
+        SinValidatorCanada.new(value, options).valid? if country == :canada
       end
     end
 
     # The Social Insurance Number is a nine-digit number in the format "AAA BBB CCC".
     # The number is divided into three parts.
     # AAA - is the first, BBB - is the second and the CCC is the third.
-    # Numbers that begin with the number "9" are issued to temporary residents who are not Canadian citizens
+    # Numbers that begin with the number "9" are issued to temporary residents who are not Canadian citizens.
+    # Numbers that begin with the number "8" are issued to businesses as "Business Numbers".
     # More details: http://en.wikipedia.org/wiki/Social_Insurance_Number
     #
     # Possible flags:
     #   allow_permanent_residents - citizens with cars, which begins with "9" are valid. By default it is false.
+    #   allow_business_numbers - business numbers, which begins with "8" are valid. By default it is false.
     #
-    #   validates :sin, :sin => {:country => :canada, :country_options => {:allow_permanent_residents => true}}
+    #   validates :sin, :sin => {:country => :canada, :country_options => {:allow_permanent_residents => true, :allow_business_numbers => true}}
     class SinValidatorCanada
       def initialize(str_value, options)
         @sin = str_value.gsub(/\D/, '') # keep only integers
         @allow_permanent_residents = false
+        @allow_business_numbers = false
 
         country_options = options.fetch(:country_options, {})
         allow_permanent_residents = country_options.fetch(:allow_permanent_residents, :nil)
+        allow_business_numbers = country_options.fetch(:allow_business_numbers, :nil)
 
-        if allow_permanent_residents == true
-          @allow_permanent_residents = true
-        end
+        @allow_permanent_residents = true if allow_permanent_residents == true
+        @allow_business_numbers = true if allow_business_numbers == true
       end
 
       def valid?
-        size_is?(9) && is_not_full_of_zeroes && allow_permanent_residents? && LuhnChecker.valid?(@sin)
+        size_is?(9) && is_not_full_of_zeroes && allow_permanent_residents? && allow_business_numbers? && LuhnChecker.valid?(@sin)
       end
 
       def size_is?(count)
@@ -53,9 +54,19 @@ module ActiveModel
       end
 
       def allow_permanent_residents?
-        permanent_residents_indentifier = "9"
+        permanent_residents_indentifier = '9'
 
         if @allow_permanent_residents == false && @sin.start_with?(permanent_residents_indentifier)
+          false
+        else
+          true
+        end
+      end
+
+      def allow_business_numbers?
+        business_indentifier = '8'
+
+        if @allow_business_numbers == false && @sin.start_with?(business_indentifier)
           false
         else
           true

--- a/test/validations/sin_test.rb
+++ b/test/validations/sin_test.rb
@@ -34,6 +34,11 @@ describe "SIN validations" do
         subject.valid?.must_equal false
       end
 
+      it "rejects valid business numbers by default" do
+        subject = build_sin_record({:sin => '897 454 286'}, {:country => :canada })
+        subject.valid?.must_equal false
+      end
+
       it "rejects invalid sin for permanent residents" do
         subject = build_sin_record({:sin => '123 456 789'}, {:country => :canada })
         subject.valid?.must_equal false
@@ -54,6 +59,12 @@ describe "SIN validations" do
       it "accept valid sin for temporary residents when flag is provided" do
         subject = build_sin_record({:sin => '996 454 286'},
                                    {:country => :canada, :country_options => { allow_permanent_residents: true } })
+        subject.valid?.must_equal true
+      end
+
+      it "accept valid business numbers when flag is provided" do
+        subject = build_sin_record({:sin => '897 454 286'},
+                                   {:country => :canada, :country_options => { allow_business_numbers: true } })
         subject.valid?.must_equal true
       end
     end


### PR DESCRIPTION
Presently the SIN validation allows business numbers to be considered "valid" even though they _are not_ SINs: https://en.wikipedia.org/wiki/Social_Insurance_Number#Geography