### PR TITLE
Validate URLs using Addressable gem to allow non-ascii characters (closes #111)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Exhaustive list of supported validators and their implementation:
 * `ssn` : Social Security Number (only for USA).
 * `tracking_number`: based on a set of predefined masks
 * `twitter` : based on a regular expression
-* `url`   : based on a regular expression
+* `url`   : based on [`Addressable`](https://github.com/sporkmonger/addressable) gem
 
 
 ### Handling error messages

--- a/activevalidators.gemspec
+++ b/activevalidators.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rake'
   s.add_dependency 'mail'
   s.add_dependency 'date_validator'
+  s.add_dependency 'addressable'            , '~> 2.7'
   s.add_dependency 'activemodel'            , '>= 3.0'
   s.add_dependency 'phony'                  , '~> 2.0'
   s.add_dependency 'countries'              , '>= 1.2', '< 4.0'

--- a/test/validations/url_test.rb
+++ b/test/validations/url_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+
 ActiveValidators.activate(:url)
 
 describe "Url Validation" do
@@ -49,6 +50,20 @@ describe "Url Validation" do
       _(subject.errors.size).must_equal(0)
     end
 
+    it "accepts valid urls with non-ascii domain name" do
+      subject = build_url_record
+      subject.url = 'https://www.詹姆斯.com'
+      _(subject.valid?).must_equal(true)
+      _(subject.errors.size).must_equal(0)
+    end
+
+    it "accepts valid urls with non-ascii path" do
+      subject = build_url_record
+      subject.url = 'https://www.example.com/ουτοπία'
+      _(subject.valid?).must_equal(true)
+      _(subject.errors.size).must_equal(0)
+    end
+
     it "accepts ftp if defined" do
       subject = build_ftp_record
       subject.url = 'ftp://ftp.verrot.fr'
@@ -67,7 +82,7 @@ describe "Url Validation" do
   describe "for invalid urls" do
     it "rejects invalid urls" do
       subject = build_url_record
-      subject.url = 'http://^^^^.fr'
+      subject.url = 'http://in va lid.fr'
       _(subject.valid?).must_equal(false)
       _(subject.errors.size).must_equal(1)
     end
@@ -81,7 +96,7 @@ describe "Url Validation" do
 
     it "generates an error message of type invalid" do
       subject = build_url_record
-      subject.url = 'http://^^^^.fr'
+      subject.url = 'http://in va lid.fr'
       _(subject.valid?).must_equal(false)
       _(subject.errors[:url].include?(subject.errors.generate_message(:url, :invalid))).must_equal(true)
     end


### PR DESCRIPTION
Warning: this allows a lot more URLs.
There is not `valid?` method on `Addressable::URI`, because many strings can be parsed and considered valid.
See https://github.com/twingly/twingly-url/issues/74#issuecomment-226334749
This change requires a minor version bump, along with a bundle install warning I think.